### PR TITLE
파워풀 컨트롤러 CORS 전 오리진 허용으로 확장

### DIFF
--- a/oracleSpringBoot/src/main/java/com/comento/oracleSpringBoot/powerfulh/PowerfulhC.java
+++ b/oracleSpringBoot/src/main/java/com/comento/oracleSpringBoot/powerfulh/PowerfulhC.java
@@ -26,7 +26,7 @@ import lombok.RequiredArgsConstructor;
 import springfox.documentation.annotations.ApiIgnore;
 
 @RestController
-@CrossOrigin(origins = {"http://localhost:5173", "https://powerfulh.github.io"}, allowCredentials = "true")
+@CrossOrigin(originPatterns = "*", allowCredentials = "true")
 @RequestMapping("powerful")
 @RequiredArgsConstructor
 public class PowerfulhC {


### PR DESCRIPTION
자격증명 유지를 위해 origins 대신 originPatterns 사용